### PR TITLE
Remove tutorials from Target Config

### DIFF
--- a/targetconfig.json
+++ b/targetconfig.json
@@ -7,6 +7,5 @@
     },
     "galleries": {
         "Examples": "examples",
-        "Tutorials": "tutorials"
     }
 }


### PR DESCRIPTION
Tutorials don't exist yet.
This produces an error on the page, as well as cause build to fail.