### PR TITLE
Removed extra comma from targetconfig.json

### DIFF
--- a/targetconfig.json
+++ b/targetconfig.json
@@ -6,6 +6,6 @@
         ]
     },
     "galleries": {
-        "Examples": "examples",
+        "Examples": "examples"
     }
 }


### PR DESCRIPTION
There is an extra comma in the targetconfig.json that makes it so pxt cannot parse the JSON and that you can't serve.