### PR TITLE
Reset loadFonts() after updated font variable

### DIFF
--- a/theme/site/globals/site.variables
+++ b/theme/site/globals/site.variables
@@ -17,6 +17,10 @@
 @googleFontName    : 'Roboto Mono';
 @importGoogleFonts : true;
 
+.loadFonts() when (@importGoogleFonts) {
+  @import (css) url('@{googleProtocol}fonts.googleapis.com/css?family=@{googleFontRequest}');
+}
+
 @docsHeaderFont: @headerFont;
 @docsPageFont: @pageFont;
 

--- a/theme/style.less
+++ b/theme/style.less
@@ -1,10 +1,10 @@
 /* Import all components */
-@import 'pxtsemantic';
 @import 'pxt';
 @import 'blockly-toolbox';
 @import 'themes/default/globals/site.variables';
 @import 'themes/pxt/globals/site.variables';
 @import 'site/globals/site.variables';
+@import 'pxtsemantic';
 
 /* Reference import */
 @import (reference) "semantic.less";


### PR DESCRIPTION
i _think_ something about upgrading semantic (https://github.com/microsoft/pxt/pull/8506) also changed the order of our variable overrides, so now `loadFont` is being defined before the target sets `googleFontName`... i looked through our changes and i think it must be something inside semantic but i couldn't pinpoint it even after a while of poking around. this fixes it but is not beautiful haha, making it a PR to your PR so you can accept/reject as you see fit